### PR TITLE
fix: Remove book info and update book covers

### DIFF
--- a/client/src/components/Hero/Hero.jsx
+++ b/client/src/components/Hero/Hero.jsx
@@ -7,7 +7,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useEffect } from 'react';
 import { fetchAllBooks } from '../../reducers/bookSlice';
 import StarIcon from '@mui/icons-material/Star';
-import Stack from '@mui/material/Stack';
+import { Link } from 'react-router-dom';
+import { Button } from '@mui/material';
 
 const Hero = () => {
 	const dispatch = useDispatch();
@@ -27,215 +28,170 @@ const Hero = () => {
 				<Grid
 					item
 					key={books[0].ISBN}>
-					<Paper
-						elevation={5}
-						sx={{
-							backgroundImage: `url(${books[0].imageUrl})`,
-							backgroundSize: 'contain',
-							width: { xs: '150px', sm: '200px' },
-							height: { xs: '200px', sm: '300px' },
-						}}>
-						<Stack
-							color={'white'}
-							gap={2}
-							px={3}
-							pt={{ xs: 1, sm: 5 }}
-							alignItems={'center'}
-							justifyContent={'center'}>
-							<Typography variant="h6">
-								{books[0].title}
-							</Typography>
-							<Typography variant="body2">
-								By: {books[0].author}
-							</Typography>
-							<Box
-								display={'flex'}
-								justifyContent={'center'}
-								alignItems={'center'}
-								gap={1}>
-								<StarIcon
-									sx={{ fill: 'yellow' }}
-									fontSize="small"></StarIcon>
-								<Typography>
-									{books[0].reviews.reduce(
-										(acc, curr) => acc + curr.rating,
-										0
-									) / books[0].reviews.length}
-								</Typography>
-							</Box>
-						</Stack>
-					</Paper>
+					<Button
+						component={Link}
+						to={'/'}>
+						<Paper
+							elevation={5}
+							sx={{
+								backgroundImage: `url(${books[0].imageUrl})`,
+								backgroundSize: 'cover',
+								backgroundRepeat: 'no-repeat',
+								width: { xs: '150px', sm: '200px' },
+								height: { xs: '200px', sm: '300px' },
+							}}></Paper>
+					</Button>
+					<Box
+						mt={2}
+						display={'flex'}
+						justifyContent={'center'}
+						alignItems={'center'}
+						gap={1}>
+						<StarIcon
+							sx={{ fill: 'gold' }}
+							fontSize="large"></StarIcon>
+						<Typography variant="h5">
+							{books[0].reviews.reduce(
+								(acc, curr) => acc + curr.rating,
+								0
+							) / books[0].reviews.length}
+						</Typography>
+					</Box>
 				</Grid>
 				<Grid
 					item
 					key={books[1].ISBN}>
-					<Paper
-						elevation={5}
-						sx={{
-							backgroundImage: `url(${books[1].imageUrl})`,
-							backgroundSize: 'contain',
-							width: { xs: '150px', sm: '200px' },
-							height: { xs: '200px', sm: '300px' },
-						}}>
-						<Stack
-							color={'white'}
-							gap={2}
-							px={3}
-							pt={{ xs: 1, sm: 5 }}
-							alignItems={'center'}
-							justifyContent={'center'}>
-							<Typography variant="h6">
-								{books[1].title}
-							</Typography>
-							<Typography variant="body2">
-								By: {books[1].author}
-							</Typography>
-							<Box
-								display={'flex'}
-								justifyContent={'center'}
-								alignItems={'center'}
-								gap={1}>
-								<StarIcon
-									sx={{ fill: 'yellow' }}
-									fontSize="small"></StarIcon>
-								<Typography>
-									{books[1].reviews.reduce(
-										(acc, curr) => acc + curr.rating,
-										0
-									) / books[1].reviews.length}
-								</Typography>
-							</Box>
-						</Stack>
-					</Paper>
+					<Button
+						component={Link}
+						to={'/'}>
+						<Paper
+							elevation={5}
+							sx={{
+								backgroundImage: `url(${books[1].imageUrl})`,
+								backgroundSize: 'cover',
+								backgroundRepeat: 'no-repeat',
+								width: { xs: '150px', sm: '200px' },
+								height: { xs: '200px', sm: '300px' },
+							}}></Paper>
+					</Button>
+					<Box
+						mt={2}
+						display={'flex'}
+						justifyContent={'center'}
+						alignItems={'center'}
+						gap={1}>
+						<StarIcon
+							sx={{ fill: 'gold' }}
+							fontSize="large"></StarIcon>
+						<Typography variant="h5">
+							{books[1].reviews.reduce(
+								(acc, curr) => acc + curr.rating,
+								0
+							) / books[1].reviews.length}
+						</Typography>
+					</Box>
 				</Grid>
 				<Grid
 					item
 					key={books[2].ISBN}
 					display={{ xs: 'none', md: 'block' }}>
-					<Paper
-						elevation={5}
-						sx={{
-							backgroundImage: `url(${books[2].imageUrl})`,
-							backgroundSize: 'contain',
-							width: { xs: '68px', sm: '200px' },
-							height: { xs: '125px', sm: '300px' },
-						}}>
-						<Stack
-							color={'white'}
-							gap={2}
-							px={3}
-							pt={{ xs: 1, sm: 5 }}
-							alignItems={'center'}
-							justifyContent={'center'}>
-							<Typography variant="h6">
-								{books[2].title}
-							</Typography>
-							<Typography variant="body2">
-								By: {books[2].author}
-							</Typography>
-							<Box
-								display={'flex'}
-								justifyContent={'center'}
-								alignItems={'center'}
-								gap={1}>
-								<StarIcon
-									sx={{ fill: 'yellow' }}
-									fontSize="small"></StarIcon>
-								<Typography>
-									{books[2].reviews.reduce(
-										(acc, curr) => acc + curr.rating,
-										0
-									) / books[2].reviews.length}
-								</Typography>
-							</Box>
-						</Stack>
-					</Paper>
+					<Button
+						component={Link}
+						to={'/'}>
+						<Paper
+							elevation={5}
+							sx={{
+								backgroundImage: `url(${books[2].imageUrl})`,
+								backgroundSize: 'cover',
+								backgroundRepeat: 'no-repeat',
+								width: { xs: '68px', sm: '200px' },
+								height: { xs: '125px', sm: '300px' },
+							}}></Paper>
+					</Button>
+					<Box
+						mt={2}
+						display={'flex'}
+						justifyContent={'center'}
+						alignItems={'center'}
+						gap={1}>
+						<StarIcon
+							sx={{ fill: 'gold' }}
+							fontSize="large"></StarIcon>
+						<Typography variant="h5">
+							{books[2].reviews.reduce(
+								(acc, curr) => acc + curr.rating,
+								0
+							) / books[2].reviews.length}
+						</Typography>
+					</Box>
 				</Grid>
 				<Grid
 					item
 					key={books[3].ISBN}
 					display={{ xs: 'none', lg: 'block' }}>
-					<Paper
-						elevation={5}
-						sx={{
-							backgroundImage: `url(${books[3].imageUrl})`,
-							backgroundSize: 'contain',
-							width: { xs: '68px', sm: '200px' },
-							height: { xs: '125px', sm: '300px' },
-						}}>
-						<Stack
-							color={'white'}
-							gap={2}
-							px={3}
-							pt={{ xs: 1, sm: 5 }}
-							alignItems={'center'}
-							justifyContent={'center'}>
-							<Typography variant="h6">
-								{books[3].title}
-							</Typography>
-							<Typography variant="body2">
-								By: {books[3].author}
-							</Typography>
-							<Box
-								display={'flex'}
-								justifyContent={'center'}
-								alignItems={'center'}
-								gap={1}>
-								<StarIcon
-									sx={{ fill: 'yellow' }}
-									fontSize="small"></StarIcon>
-								<Typography>
-									{books[3].reviews.reduce(
-										(acc, curr) => acc + curr.rating,
-										0
-									) / books[3].reviews.length}
-								</Typography>
-							</Box>
-						</Stack>
-					</Paper>
+					<Button
+						component={Link}
+						to={'/'}>
+						<Paper
+							elevation={5}
+							sx={{
+								backgroundImage: `url(${books[3].imageUrl})`,
+								backgroundSize: 'cover',
+								backgroundRepeat: 'no-repeat',
+								width: { xs: '68px', sm: '200px' },
+								height: { xs: '125px', sm: '300px' },
+							}}></Paper>
+					</Button>
+					<Box
+						mt={2}
+						display={'flex'}
+						justifyContent={'center'}
+						alignItems={'center'}
+						gap={1}>
+						<StarIcon
+							sx={{ fill: 'gold' }}
+							fontSize="large"></StarIcon>
+						<Typography variant="h5">
+							{books[3].reviews.reduce(
+								(acc, curr) => acc + curr.rating,
+								0
+							) / books[3].reviews.length}
+						</Typography>
+					</Box>
 				</Grid>
 				<Grid
 					item
 					key={books[4].ISBN}
 					display={{ xs: 'none', lg: 'block' }}>
-					<Paper
-						elevation={5}
-						sx={{
-							backgroundImage: `url(${books[4].imageUrl})`,
-							backgroundSize: 'contain',
-							width: { xs: '68px', sm: '200px' },
-							height: { xs: '125px', sm: '300px' },
-						}}>
-						<Stack
-							color={'white'}
-							gap={2}
-							px={3}
-							pt={{ xs: 1, sm: 5 }}
-							alignItems={'center'}
-							justifyContent={'center'}>
-							<Typography variant="h6">
-								{books[4].title}
-							</Typography>
-							<Typography variant="body2">
-								By: {books[4].author}
-							</Typography>
-							<Box
-								display={'flex'}
-								justifyContent={'center'}
-								alignItems={'center'}
-								gap={1}>
-								<StarIcon
-									sx={{ fill: 'yellow' }}
-									fontSize="small"></StarIcon>
-								<Typography>
-									{books[4].reviews.reduce(
-										(acc, curr) => acc + curr.rating,
-										0
-									) / books[4].reviews.length}
-								</Typography>
-							</Box>
-						</Stack>
-					</Paper>
+					<Button
+						component={Link}
+						to={'/'}>
+						<Paper
+							elevation={5}
+							sx={{
+								backgroundImage: `url(${books[4].imageUrl})`,
+								backgroundSize: 'cover',
+								backgroundRepeat: 'no-repeat',
+								width: { xs: '68px', sm: '200px' },
+								height: { xs: '125px', sm: '300px' },
+							}}></Paper>
+					</Button>
+					<Box
+						mt={2}
+						display={'flex'}
+						justifyContent={'center'}
+						alignItems={'center'}
+						gap={1}>
+						<StarIcon
+							sx={{ fill: 'gold' }}
+							fontSize="large"></StarIcon>
+						<Typography variant="h5">
+							{books[4].reviews.reduce(
+								(acc, curr) => acc + curr.rating,
+								0
+							) / books[4].reviews.length}
+						</Typography>
+					</Box>
 				</Grid>
 			</>
 		) : null;


### PR DESCRIPTION
Purpose: Update Hero component to accommodate the changes to the book seeder. Add navigation to each book cover and fix styling of book covers.

What Changed: 
- Removed book author and title from Hero books
- Moved star rating to beneath the Book covers 
- Updated book images to stop repeating and to fit containers
- Added a Button component to each book cover

How to Review:

- [ ] Visit landing page
- [ ] Interact and view books on page

![Screenshot 2024-06-10 at 11 07 12 AM](https://github.com/chingu-voyages/v49-tier3-team-29/assets/48105264/a71f6fbb-9528-4aa9-9f87-bf4b5bf4f8c2)

Notes: For now, each book is linked to the homepage. When the Book page component is finished we can link these to each book's individual page

