### PR TITLE
fix: Fix api urls for different app modes

### DIFF
--- a/client/src/utils/baseUrl.js
+++ b/client/src/utils/baseUrl.js
@@ -1,5 +1,7 @@
-export const bookBaseURL = "http://localhost:5001/books";
-export const userBaseURL = "http://localhost:5001/users";
-export const listBaseURL = "http://localhost:5001/lists";
-export const reviewBaseURL = 'http://localhost:5001/reviews';
+// Create a .env file with VITE_BACKENDURL to make requests to backend
+const backendURL = import.meta.env.VITE_BACKENDURL;
 
+export const bookBaseURL = `${backendURL}/books`;
+export const userBaseURL = `${backendURL}/users`;
+export const listBaseURL = `${backendURL}/lists`;
+export const reviewBaseURL = `${backendURL}/reviews`;


### PR DESCRIPTION
Purpose: Access the proper backend URL for different modes of the app. For example: Render dev static-site should call Render dev web-service. 

What changed: 
- baseUrl for each API endpoint was updated to use env variable for the backend URL

How to Review:
- [ ] Try to sign in with no VITE_BACKENDURL and make sure cant login
- [ ] Try to sign in with .env file created and VITE_BACKENDURL set to localhost url
- [ ] Try to sign in with VITE_BACKENDURL set to the Render dev backend url
- [ ] Try to sign in with VITE_BACKENDURL set to the Render prod backend URL

Notes: When this branch is merged I will update the Render client environment variables to match up to their backends.